### PR TITLE
Set stdout as default output for loggin

### DIFF
--- a/singlebeat/log.py
+++ b/singlebeat/log.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import logging
-
+import sys
 
 class SingleBeatLog(object):
     """
@@ -10,9 +10,12 @@ class SingleBeatLog(object):
     """
 
     def __init__(self, level=logging.INFO, filename=None):
-        logging.basicConfig(
-            level=level,
-            format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-            datefmt='%m-%d %H:%M',
-            filename=filename or '/var/log/singlebeat.log')
+        basicConfig = {"level":level,
+            "format":'%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+            "datefmt":'%m-%d %H:%M'}
+        if filename:
+            basicConfig['filename'] = filename
+        else:
+            basicConfig['stream'] = sys.stdout
+        logging.basicConfig(**basicConfig)
         self.logger = logging.getLogger('singlebeat')


### PR DESCRIPTION
When SINGLE BEAT LOG_FILENAME variable is set, the logging output goes to the file, otherwise the output of the logging is set with stdout.
